### PR TITLE
fix: use /home/user/.gradle as a gradle volume

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -20,7 +20,7 @@ components:
           value: /home/user/.gradle
       volumeMounts:
         - name: gradle
-          path: /home/jboss/.gradle
+          path: /home/user/.gradle
       mountSources: true
   - name: m2
     volume:


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>
Fix path of the gradle volume