### PR TITLE
chore: add missing java related extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,9 @@
     // See https://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-      "redhat.java"
+      "redhat.java",
+      "vscjava.vscode-java-debug",
+      "vscjava.vscode-java-test",
+      "redhat.fabric8-analytics"
     ]
 }


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

This pull request
- adds missing `vscjava.vscode-java-debug` and `vscjava.vscode-java-test` extensions
- adds `redhat.fabric8-analytics` extension

Solves https://issues.redhat.com/browse/CRW-3302, https://issues.redhat.com/browse/CRW-3216

Use following URI to create a workspace with factory
https://github.com/vitaliy-guliy/gs-validating-form-input?che-editor=che-incubator/che-code/insiders
